### PR TITLE
Define inspect property on switchback instead of (potentially) global context

### DIFF
--- a/lib/factory.js
+++ b/lib/factory.js
@@ -52,7 +52,7 @@ module.exports = function(callbackContext) {
   _switch[constants.telltale.key] = constants.telltale.value;
 
   // Mix in non-enumerable `.inspect()` method
-  Object.defineProperty(this, 'inspect', { enumerable: false, writable: true });
+  Object.defineProperty(_switch, 'inspect', { enumerable: false, writable: true });
   _switch.inspect = function () { return '[Switchback]'; };
 
   return _switch;


### PR DESCRIPTION
I think that this was just a small mistake.  It was leaking an undefined `inspect` onto `global`, though, which isn't good.