### PR TITLE
Fixed factory creation

### DIFF
--- a/lib/factory.js
+++ b/lib/factory.js
@@ -6,6 +6,7 @@ var _ = require('lodash');
 var constants = require('./constants');
 
 
+module.exports = Factory;
 
 /**
  * factory
@@ -22,7 +23,10 @@ var constants = require('./constants');
  * "just work".
  */
 
-module.exports = function(callbackContext) {
+function Factory(callbackContext) {
+  if (!(this instanceof Factory)) {
+    return new Factory(callbackContext);
+  }
 
   var _switch = function( /* err, arg1, arg2, ..., argN */ ) {
     var args = Array.prototype.slice.call(arguments);
@@ -56,4 +60,4 @@ module.exports = function(callbackContext) {
   _switch.inspect = function () { return '[Switchback]'; };
 
   return _switch;
-};
+}


### PR DESCRIPTION
Hi, this fix is a part of https://github.com/balderdashy/waterline/issues/1080 issue. 
`switchback` was failing in `io.js` strict mode.
